### PR TITLE
Fix start function.

### DIFF
--- a/pywasm/execution.py
+++ b/pywasm/execution.py
@@ -366,7 +366,8 @@ class ModuleInstance:
             m.data[offset.n: offset.n + len(e.init)] = e.init
         # If the start function module.start is not empty, invoke the function instance
         if module.start is not None:
-            call(module, module.start, store, stack)
+            log.debugln(f'Running start function {module.start}:')
+            call(self, module.start, store, stack)
 
     def allocate(
         self,

--- a/pywasm/structure.py
+++ b/pywasm/structure.py
@@ -413,6 +413,9 @@ class StartFunction:
     # start ::= {func funcidx}
     def __init__(self):
         self.funcidx: int
+    
+    def __repr__(self):
+        return f'StartFunction[{self.funcidx}]'
 
     @classmethod
     def from_reader(cls, r: typing.BinaryIO):
@@ -800,8 +803,8 @@ class Module:
                 mod.exports = export_section.vec
             elif section_id == convention.start_section:
                 start_section = StartSection.from_reader(io.BytesIO(data))
-                log.debugln(start_section)
-                mod.start = start_section.start_function
+                log.debugln(f'{convention.section[section_id][0]:>12} {start_section.start_function}')
+                mod.start = start_section.start_function.funcidx
             elif section_id == convention.element_section:
                 element_section = ElementSection.from_reader(io.BytesIO(data))
                 for i, e in enumerate(element_section.vec):


### PR DESCRIPTION
First off, thank you for this library. It works great and the interface is fantastic. We are using it for teaching compilers and embedding it in a Jupyter notebook. The debug trace is very helpful for that. 

This PR fixes a small bug in the execution of the start segment. It stores the `funcidx` of the start function in the `module.start` field rather than the instance and properly indicate the start segment and initial function call in the debug logs.