### PR TITLE
Debugging/tracing additions

### DIFF
--- a/pywasm/__init__.py
+++ b/pywasm/__init__.py
@@ -48,7 +48,6 @@ class VirtualMachine:
             args[i] = execution.Value(e, args[i])
         stack = execution.Stack()
         stack.ext(args)
-        frame = execution.Frame(self.module_instance, args, len(func.functype.rets), -1)
         log.debugln(f'Running function {name}({", ".join([str(e) for e in args])}):')
         r = execution.call(self.module_instance, func_addr, self.store, stack)
         if r:

--- a/pywasm/execution.py
+++ b/pywasm/execution.py
@@ -628,7 +628,10 @@ def exec_expr(
             stack.add(store.globals[module.globaladdrs[i.immediate_arguments]].value)
             continue
         if opcode == convention.set_global:
-            store.globals[module.globaladdrs[i.immediate_arguments]] = GlobalInstance(stack.pop(), True)
+            addr = module.globaladdrs[i.immediate_arguments]
+            store.globals[addr] = GlobalInstance(stack.pop(), True)
+            # mirror the update in the stack for debugging even if get_global uses the local duplicate in the GlobalInstance
+            stack.data[addr] = store.globals[addr].value
             continue
         if opcode >= convention.i32_load and opcode <= convention.grow_memory:
             m = store.mems[module.memaddrs[0]]

--- a/pywasm/log.py
+++ b/pywasm/log.py
@@ -8,6 +8,9 @@ def debugln(*args):
     if lvl:
         println(*args)
 
+def verboseln(*args):
+    if lvl >= 2:
+        println(*args)
 
 def println(*args):
     pre = datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S')


### PR DESCRIPTION
The logs are very helpful for debugging hand written wasm as you can see the stack as it changes from execution of the instructions. This PR further completes these messages. No rush with this, I am happy to extend it further or make some changes if there are places we can still improve things.

Completes a bit more of the string serialization of the structure classes for use in the debug messages. Also store the global variable values in their appropriate place on the stack (despite it not being necessary as a copy is saved in `GlobalInstance.value`) for use when printing the stack.

For example, this trace with 3 globals and some code that sets the first to 41:
```
2019/03/07 17:36:57 i32.const 0        [*]
2019/03/07 17:36:57 end                [*, 0]
2019/03/07 17:36:57 i32.const 0        [0, *]
2019/03/07 17:36:57 end                [0, *, 0]
2019/03/07 17:36:57 i32.const 0        [0, 0, *]
2019/03/07 17:36:57 end                [0, 0, *, 0]
2019/03/07 17:36:57 Running start function 5:
2019/03/07 17:36:57 i32.const 41       [0, 0, 0, *, |]
2019/03/07 17:36:57 global.set 0       [0, 0, 0, *, |, 41]
2019/03/07 17:36:57 i32.const 100      [41, 0, 0, *, |]
2019/03/07 17:36:57 call 3             [41, 0, 0, *, |, 100]
```

and this which shows the value for the block return types, local types, as well as correct function indexes:
```
2019/03/07 17:36:57      Code[0] func=3 locals=[]
2019/03/07 17:36:57            | i32.const 42
2019/03/07 17:36:57            | call 0
2019/03/07 17:36:57            | end
2019/03/07 17:36:57      Code[1] func=4 locals=[i32, i32]
2019/03/07 17:36:57            | i32.const 0
2019/03/07 17:36:57            | local.set 2
2019/03/07 17:36:57            | local.get 0
2019/03/07 17:36:57            | local.set 3
2019/03/07 17:36:57            | block empty
2019/03/07 17:36:57            |   loop empty
2019/03/07 17:36:57            |     local.get 3
```