### PR TITLE
Rename struct Vm to Runtime

### DIFF
--- a/pywasm/__init__.py
+++ b/pywasm/__init__.py
@@ -25,9 +25,15 @@ class Runtime:
                 externvals.append(execution.ExternValue(e.kind, len(self.store.funcs) - 1))
                 continue
             if e.kind == convention.extern_table:
-                raise NotImplementedError
+                a = imps[e.module][e.name]
+                self.store.tables.append(a)
+                externvals.append(execution.ExternValue(e.kind, len(self.store.tables) - 1))
+                continue
             if e.kind == convention.extern_mem:
-                raise NotImplementedError
+                a = imps[e.module][e.name]
+                self.store.mems.append(a)
+                externvals.append(execution.ExternValue(e.kind, len(self.store.mems) - 1))
+                continue
             if e.kind == convention.extern_global:
                 a = execution.GlobalInstance(execution.Value(e.desc.valtype, imps[e.module][e.name]), e.desc.mut)
                 self.store.globals.append(a)
@@ -70,7 +76,7 @@ def on_debug():
     log.lvl = 1
 
 
-def load(name: str, imps: typing.Dict = None):
+def load(name: str, imps: typing.Dict = None) -> Runtime:
     # Generate a runtime directly by loading a file from disk.
     with open(name, 'rb') as f:
         module = structure.Module.from_reader(f)

--- a/pywasm/execution.py
+++ b/pywasm/execution.py
@@ -271,9 +271,7 @@ def import_matching_limits(limits1: structure.Limits, limits2: structure.Limits)
     m1 = limits1.maximum
     n2 = limits2.minimum
     m2 = limits2.maximum
-    if n1 < n2:
-        return False
-    if m2 is None or (m1 != None and m2 != None and m1 <= m2):
+    if m2 is None or (m1 != None and m1 <= m2):
         return True
     return False
 
@@ -328,7 +326,7 @@ class ModuleInstance:
             elif e.extern_type == convention.extern_mem:
                 a = store.mems[e.addr]
                 b = module.imports[i].desc
-                assert import_matching_limits(b, a)
+                assert import_matching_limits(b, a.limits)
             elif e.extern_type == convention.extern_global:
                 a = store.globals[e.addr]
                 b = module.imports[i].desc

--- a/pywasm/structure.py
+++ b/pywasm/structure.py
@@ -46,7 +46,7 @@ class Limits:
     #
     # limits ::= 0x00  n:u32        ⇒ {min n,max ϵ}
     #          | 0x01  n:u32  m:u32 ⇒ {min n,max m}
-    def __init__(self, minimum: int, maximum: int):
+    def __init__(self, minimum: int, maximum: int = None):
         self.minimum = minimum
         self.maximum = maximum
 
@@ -78,7 +78,7 @@ class MemoryType:
 class TableType:
     # Table types classify tables over elements of element types within a size range.
     #
-    # tabletype :: =limits elemtype
+    # tabletype ::= limits elemtype
     # elemtype ::= funcref
     #
     # Like memories, tables are constrained by limits for their minimum and optionally maximum size. The limits are
@@ -88,6 +88,10 @@ class TableType:
     def __init__(self):
         self.limits: Limits
         self.elemtype: int
+
+    def __repr__(self):
+        a = convention.elemtype[self.elemtype][0]
+        return f'{a} {self.limits}'
 
     @classmethod
     def from_reader(cls, r: typing.BinaryIO):
@@ -109,9 +113,10 @@ class GlobalType:
         self.mut: bool
 
     def __repr__(self):
+        a = convention.valtype[self.valtype][0]
         if self.mut:
-            return f'var {convention.valtype[self.valtype]}'
-        return f'const {convention.valtype[self.valtype]}'
+            return f'var {a}'
+        return f'const {a}'
 
     @classmethod
     def from_reader(cls, r: typing.BinaryIO):


### PR DESCRIPTION
Naming is more in line with standards.

See: https://webassembly.github.io/spec/core/bikeshed/index.html#runtime-structure①