### PR TITLE
Use integer division for popcnt

### DIFF
--- a/pywasm/execution.py
+++ b/pywasm/execution.py
@@ -866,7 +866,7 @@ def exec_expr(
                 for i in range(32):
                     if 0x1 & a:
                         c += 1
-                    a /= 2
+                    a //= 2
                 stack.add(Value.from_i32(c))
                 continue
             continue
@@ -953,7 +953,7 @@ def exec_expr(
                 for i in range(64):
                     if 0x1 & a:
                         c += 1
-                    a /= 2
+                    a //= 2
                 stack.add(Value.from_i64(c))
                 continue
             continue


### PR DESCRIPTION
Prior to this commit: the `0x1 & a` expression will fail after the first iteration when `a` becomes a `float` from the `/=` statement.

e.g.,

```
                if opcode == convention.i64_popcnt:
                    c = 0
                    for i in range(64):
>                       if 0x1 & a:
E                       TypeError: unsupported operand type(s) for &: 'int' and 'float'

/usr/local/lib/python3.7/site-packages/pywasm/execution.py:958: TypeError
```