### PR TITLE
raise exception when decoding unknown instruction

### DIFF
--- a/pywasm/binary.py
+++ b/pywasm/binary.py
@@ -318,6 +318,8 @@ class Instruction:
         if o.opcode == instruction.f64_const:
             o.args = [num.LittleEndian.i64(r.read(8))]
             return o
+        if o.opcode not in instruction.opcode:
+            raise Exception("unsupported opcode", o.opcode)
         return o
 
 # ======================================================================================================================


### PR DESCRIPTION
When using pywasm to load a module containing instructions not supported by pywasm (such as memory.copy and memory.fill, encoded with the 0xfc byte prefix), the binary decoder assumes they are one byte long and proceeds decoding, leading to all kinds of confusion.

This change makes sure that all decoded instructions are explicitly listed in `instruction.opcode`, which prevents this kind of confusion at decode time.